### PR TITLE
Update xo

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "remark-lint": "^8.0.0",
     "remark-preset-wooorm": "^8.0.0",
     "tape": "^5.0.0",
-    "xo": "^0.34.0"
+    "xo": "^0.38.0"
   },
   "scripts": {
     "format": "remark . -qfo && prettier . -w --loglevel warn && xo --fix",


### PR DESCRIPTION
The previous version of `xo` doesn’t support the `async` keyword, which is going to be necessary if `load-plugin` should support ESM imports.