### PR TITLE
Generate type definitions from jsdoc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 .DS_Store
+*.d.ts
 *.log
+*.tgz
 .nyc_output/
 coverage/
 /node_modules/

--- a/index.js
+++ b/index.js
@@ -1,8 +1,16 @@
 'use strict'
 
+/**
+ * @typedef {object} LoadPluginOptions
+ * @property {string} [prefix]
+ * @property {string | string[]} [cwd]
+ * @property {boolean} [global]
+ */
+
 var fs = require('fs')
 var path = require('path')
 var resolve = require('resolve-from').silent
+// type-coverage:ignore-next-line
 var readNpmConfig = require('libnpmconfig').read
 
 module.exports = loadPlugin
@@ -18,6 +26,7 @@ var appData = process.env.APPDATA
 /* istanbul ignore next */
 var globalsLibrary = windows ? '' : 'lib'
 
+// type-coverage:ignore-next-line
 var builtinNpmConfig
 
 // The prefix config defaults to the location where node is installed.
@@ -25,6 +34,7 @@ var builtinNpmConfig
 // pass to `libnpmconfig` explicitly:
 /* istanbul ignore next */
 if (windows && appData) {
+  // type-coverage:ignore-next-line
   builtinNpmConfig = {prefix: path.join(appData, 'npm')}
 }
 
@@ -55,41 +65,48 @@ if (electron && nvm && !fs.existsSync(globals)) {
   globals = path.resolve(nvm, '..', globalsLibrary, 'node_modules')
 }
 
-// Load the plugin found using `resolvePlugin`.
+/**
+ *  Load the plugin found using `resolvePlugin`.
+ *
+ * @param {string} name The name to import.
+ * @param {LoadPluginOptions} [options]
+ * @returns {any}
+ */
 function loadPlugin(name, options) {
   return require(resolvePlugin(name, options) || name)
 }
 
-// Find a plugin.
-//
-// See also:
-// <https://docs.npmjs.com/files/folders#node-modules>
-// <https://github.com/sindresorhus/resolve-from>
-//
-// Uses the standard node module loading strategy to find $name in each given
-// `cwd` (and optionally the global `node_modules` directory).
-//
-// If a prefix is given and $name is not a path, `$prefix-$name` is also
-// searched (preferring these over non-prefixed modules).
+/**
+ * Find a plugin.
+ *
+ * See also:
+ * *   https://docs.npmjs.com/files/folders#node-modules
+ * *   https://github.com/sindresorhus/resolve-from
+ *
+ * Uses the standard node module loading strategy to find $name in each given
+ * `cwd` (and optionally the global `node_modules` directory).
+ *
+ * If a prefix is given and $name is not a path, `$prefix-$name` is also
+ * searched (preferring these over non-prefixed modules).
+ *
+ * @param {string} name
+ * @param {LoadPluginOptions} [options]
+ * @returns {string | null}
+ */
 function resolvePlugin(name, options) {
   var settings = options || {}
   var prefix = settings.prefix
   var cwd = settings.cwd
   var global = settings.global
-  var filePath
-  var sources
-  var length
-  var index
+  /** @type string */
   var plugin
-  var slash
   var scope = ''
 
   if (global === null || global === undefined) {
     global = globally
   }
 
-  sources =
-    cwd && typeof cwd === 'object' ? cwd.concat() : [cwd || process.cwd()]
+  var sources = Array.isArray(cwd) ? cwd.concat() : [cwd || process.cwd()]
 
   // Non-path.
   if (name.charAt(0) !== '.') {
@@ -103,7 +120,7 @@ function resolvePlugin(name, options) {
 
       // Scope?
       if (name.charAt(0) === '@') {
-        slash = name.indexOf('/')
+        var slash = name.indexOf('/')
 
         // Let’s keep the algorithm simple.
         // No need to care if this is a “valid” scope (I think?).
@@ -122,12 +139,12 @@ function resolvePlugin(name, options) {
     }
   }
 
-  length = sources.length
-  index = -1
+  var length = sources.length
+  var index = -1
 
   while (++index < length) {
-    cwd = sources[index]
-    filePath = (plugin && resolve(cwd, plugin)) || resolve(cwd, name)
+    var dir = sources[index]
+    var filePath = (plugin && resolve(dir, plugin)) || resolve(dir, name)
 
     if (filePath) {
       return filePath

--- a/package.json
+++ b/package.json
@@ -35,14 +35,19 @@
     "remark-cli": "^9.0.0",
     "remark-lint": "^8.0.0",
     "remark-preset-wooorm": "^8.0.0",
+    "rimraf": "^3.0.0",
     "tape": "^5.0.0",
+    "type-coverage": "^2.0.0",
+    "typescript": "^4.0.0",
     "xo": "^0.38.0"
   },
   "scripts": {
+    "build": "rimraf \"*.d.ts\" && tsc && type-coverage",
     "format": "remark . -qfo && prettier . -w --loglevel warn && xo --fix",
     "test-api": "node test",
     "test-coverage": "nyc --reporter lcov tape test/index.js",
-    "test": "npm run format && npm run test-coverage"
+    "test": "npm run format && npm run test-coverage",
+    "prepack": "npm run build && npm run format"
   },
   "prettier": {
     "tabWidth": 2,
@@ -72,5 +77,10 @@
     "plugins": [
       "preset-wooorm"
     ]
+  },
+  "typeCoverage": {
+    "atLeast": 100,
+    "detail": true,
+    "strict": true
   }
 }

--- a/package.json
+++ b/package.json
@@ -54,7 +54,13 @@
   },
   "xo": {
     "prettier": true,
-    "esnext": false
+    "rules": {
+      "capitalized-comments": "off",
+      "import/no-mutable-exports": "off",
+      "no-misleading-character-class": "off",
+      "no-var": "off",
+      "prefer-arrow-callback": "off"
+    }
   },
   "nyc": {
     "check-coverage": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "files": ["index.js"],
+  "compilerOptions": {
+    "target": "ES2020",
+    "lib": ["ES2020"],
+    "module": "ES2020",
+    "moduleResolution": "node",
+    "allowJs": true,
+    "checkJs": true,
+    "declaration": true,
+    "emitDeclarationOnly": true,
+    "skipLibCheck": true
+  }
+}


### PR DESCRIPTION
I also changed the XO configuration to match recent projects.

No types exist for `libnpmconfig`. I think the npm team forgot to mark it for deprecation, because it relies heavily on `figgy-pudding`, which is marked for deprecation. I used `type-coverage:ignore-next-line` comments to ignore type coverage checks for lines telated to this library.

I disabled XO rule `capitalized-comments`, because it was reporting `type-coverage:ignore-next-line` comments.