### PR TITLE
Remove top-level await to ease bundling to CJS

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -33,7 +33,7 @@
  *   Prefix to search for (optional).
  */
 
-import fs from 'node:fs/promises'
+import fs from 'node:fs'
 import path from 'node:path'
 import process from 'node:process'
 import {fileURLToPath, pathToFileURL} from 'node:url'
@@ -88,15 +88,8 @@ let globalFolder = new URL(nodeModules, pathToFileURL(npmPrefix) + '/')
 // Luckily NVM leaks some environment variables that we can pick up on to try
 // and detect the actual modules.
 /* c8 ignore next 10 -- Electron. */
-if (electron && nvm) {
-  try {
-    await fs.stat(globalFolder)
-  } catch (error) {
-    const cause = /** @type {NodeJS.ErrnoException} */ (error)
-    if (cause && cause.code === 'ENOENT') {
-      globalFolder = new URL(nodeModules, pathToFileURL(nvm))
-    }
-  }
+if (electron && nvm && !fs.existsSync(globalFolder)) {
+  globalFolder = new URL(nodeModules, pathToFileURL(nvm))
 }
 
 /**


### PR DESCRIPTION
It’s fine to use top-level await in ESM, but not in CJS. This package is used either directly or indirectly by some VSCode extensions in the unified ecosystem. These can’t run ESM, and must compile the code to CJS.