### PR TITLE
Fix resolving globally installed npm packages

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -34,11 +34,9 @@
  */
 
 import fs from 'node:fs'
-import path from 'node:path'
 import process from 'node:process'
-import {fileURLToPath, pathToFileURL} from 'node:url'
-// @ts-expect-error: untyped
-import NpmConfig from '@npmcli/config'
+import {pathToFileURL} from 'node:url'
+import globalDirectory from 'global-directory'
 import {resolve} from 'import-meta-resolve'
 
 const electron = process.versions.electron !== undefined
@@ -47,24 +45,13 @@ const windows = process.platform === 'win32'
 const argv = process.argv[1] || /* c8 ignore next -- windows */ ''
 const nvm = process.env.NVM_BIN
 
-const config = new NpmConfig({
-  definitions: {},
-  npmPath: fileURLToPath(new URL('.', import.meta.url))
-})
-
-config.loadGlobalPrefix()
-
 // Note: this is a file path.
 // If there is no prefix defined,
 // use the defaults.
 // See: <https://github.com/eush77/npm-prefix/blob/master/index.js>
 /* c8 ignore next 6 -- typically defined */
 /** @type {string} */
-const npmPrefix =
-  config.globalPrefix ||
-  (windows
-    ? path.dirname(process.execPath)
-    : path.resolve(process.execPath, '../..'))
+const npmPrefix = globalDirectory.npm.prefix
 
 const defaultGlobal = electron || argv.startsWith(npmPrefix)
 /** @type {Readonly<LoadOptions>} */
@@ -75,7 +62,7 @@ const defaultResolveOptions = {}
 /* c8 ignore next -- windows */
 const nodeModules = windows ? 'node_modules' : 'lib/node_modules'
 
-let globalFolder = new URL(nodeModules, pathToFileURL(npmPrefix) + '/')
+let globalFolder = pathToFileURL(globalDirectory.npm.packages)
 
 // If we’re in Electron,
 // we’re running in a modified Node that cannot really install global node


### PR DESCRIPTION
I expected that I would be able to load modules installed with `npm install --global` when passing the `global` option to `loadPlugin`, but it doesn’t work.

My global `.npmrc`:

```ini
audit=false
cache=/home/remco/.cache/npm
init-author-email=remcohaszing@gmail.com
init-author-name=Remco Haszing
init-license=MIT
prefix=/home/remco/.local
update-notifier=false
```

```sh
$ npm ls --global
/home/remco/.local/lib
├── @arethetypeswrong/cli@0.13.10
├── @reporters/testwatch@1.4.3
├── bun@1.0.26
├── httpster@1.2.1
├── react-devtools@5.0.0
├── tsx@4.7.1
├── webpack-bundle-analyzer@4.10.1
└── yarn-deduplicate@6.0.2
```

```
$ node           
Welcome to Node.js v18.19.1.
Type ".help" for more information.
> const { loadPlugin } = await import('load-plugin')
[Module: null prototype] {
  loadPlugin: [AsyncFunction: loadPlugin],
  resolvePlugin: [AsyncFunction: resolvePlugin]
}
> await loadPlugin('tsx', {global: true})
Uncaught:
Error [ERR_MODULE_NOT_FOUND]: Cannot find package 'tsx' imported from /usr/lib/node_modules
    at __node_internal_ (file:///home/remco/Projects/load-plugin/node_modules/import-meta-resolve/lib/errors.js:431:11)
    at new NodeError (file:///home/remco/Projects/load-plugin/node_modules/import-meta-resolve/lib/errors.js:374:5)
    at packageResolve (file:///home/remco/Projects/load-plugin/node_modules/import-meta-resolve/lib/resolve.js:1038:9)
    at moduleResolve (file:///home/remco/Projects/load-plugin/node_modules/import-meta-resolve/lib/resolve.js:1101:20)
    at defaultResolve (file:///home/remco/Projects/load-plugin/node_modules/import-meta-resolve/lib/resolve.js:1266:15)
    at resolve (file:///home/remco/Projects/load-plugin/node_modules/import-meta-resolve/index.js:32:12)
    at resolvePlugin (file:///home/remco/Projects/load-plugin/lib/index.js:205:14)
    at Module.loadPlugin (file:///home/remco/Projects/load-plugin/lib/index.js:123:22)
    at REPL2:1:48 {
  code: 'ERR_MODULE_NOT_FOUND'
}
```

I managed to make this work by replacing [`@npmcli/config`](https://github.com/npm/cli/tree/latest/workspaces/config) with [`global-directory`](https://github.com/sindresorhus/global-directory). This also removes the dependency on `import.meta.url`, which is still a reason this package needs hacks to be usable when compiled to CJS (#16). As a bonus it has much fewer indirect dependencies.

The broken test relies on a detail on the environment it runs in. If these changes are wanted, I intend to actually install a package globally in CI instead to provide a more robust test case.