### PR TITLE
Fix resolving globally installed npm packages

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,6 +8,7 @@ jobs:
         with:
           node-version: node
       - run: npm install
+      - run: npm install --global f-ck@2
       - run: npm test
       - uses: codecov/codecov-action@v3
   no-nvm:
@@ -19,6 +20,7 @@ jobs:
         with:
           node-version: ${{matrix.node}}
       - run: npm install
+      - run: npm install --global f-ck@2
       - run: npm run test-coverage
     strategy:
       matrix:
@@ -37,6 +39,7 @@ jobs:
         with:
           node-version: ${{matrix.node}}
       - run: npm install
+      - run: npm install --global f-ck@2
       - run: npm run test-coverage
     strategy:
       matrix:

--- a/lib/index.js
+++ b/lib/index.js
@@ -36,9 +36,11 @@
 import fs from 'node:fs'
 import path from 'node:path'
 import process from 'node:process'
-import {fileURLToPath, pathToFileURL} from 'node:url'
+import {pathToFileURL} from 'node:url'
 // @ts-expect-error: untyped
 import NpmConfig from '@npmcli/config'
+// @ts-expect-error: untyped
+import definitions from '@npmcli/config/lib/definitions/definitions.js'
 import {resolve} from 'import-meta-resolve'
 
 const electron = process.versions.electron !== undefined
@@ -48,49 +50,57 @@ const argv = process.argv[1] || /* c8 ignore next -- windows */ ''
 const nvm = process.env.NVM_BIN
 
 const config = new NpmConfig({
-  definitions: {},
-  npmPath: fileURLToPath(new URL('.', import.meta.url))
+  argv: [],
+  definitions,
+  npmPath: ''
 })
-
-config.loadGlobalPrefix()
 
 // Note: this is a file path.
 // If there is no prefix defined,
 // use the defaults.
 // See: <https://github.com/eush77/npm-prefix/blob/master/index.js>
-/* c8 ignore next 6 -- typically defined */
-/** @type {string} */
-const npmPrefix =
-  config.globalPrefix ||
-  (windows
-    ? path.dirname(process.execPath)
-    : path.resolve(process.execPath, '../..'))
+/** @type {string | Promise<string>} */
+let npmPrefix = config.load().then(() => {
+  npmPrefix =
+    /* c8 ignore next 6 -- typically defined */
+    config.globalPrefix ||
+    (windows
+      ? path.dirname(process.execPath)
+      : path.resolve(process.execPath, '../..'))
+  return npmPrefix
+})
 
-const defaultGlobal = electron || argv.startsWith(npmPrefix)
 /** @type {Readonly<LoadOptions>} */
 const defaultLoadOptions = {}
 /** @type {Readonly<ResolveOptions>} */
 const defaultResolveOptions = {}
 
-/* c8 ignore next -- windows */
-const nodeModules = windows ? 'node_modules' : 'lib/node_modules'
+/** @type {URL | Promise<URL>} */
+let globalFolder = /** @type {Promise<string>} */ (npmPrefix).then(
+  (npmPrefix) => {
+    /* c8 ignore next -- windows */
+    const nodeModules = windows ? 'node_modules' : 'lib/node_modules'
 
-let globalFolder = new URL(nodeModules, pathToFileURL(npmPrefix) + '/')
+    globalFolder = new URL(nodeModules, pathToFileURL(npmPrefix) + '/')
 
-// If we’re in Electron,
-// we’re running in a modified Node that cannot really install global node
-// modules.
-// To find the actual modules,
-// the user has to set `prefix` somewhere in an `.npmrc` (which is picked up
-// by `@npmcli/config`).
-// Most people don’t do that,
-// and some use NVM instead to manage different versions of Node.
-// Luckily NVM leaks some environment variables that we can pick up on to try
-// and detect the actual modules.
-/* c8 ignore next 10 -- Electron. */
-if (electron && nvm && !fs.existsSync(globalFolder)) {
-  globalFolder = new URL(nodeModules, pathToFileURL(nvm))
-}
+    // If we’re in Electron,
+    // we’re running in a modified Node that cannot really install global node
+    // modules.
+    // To find the actual modules,
+    // the user has to set `prefix` somewhere in an `.npmrc` (which is picked up
+    // by `@npmcli/config`).
+    // Most people don’t do that,
+    // and some use NVM instead to manage different versions of Node.
+    // Luckily NVM leaks some environment variables that we can pick up on to try
+    // and detect the actual modules.
+    /* c8 ignore next 10 -- Electron. */
+    if (electron && nvm && !fs.existsSync(globalFolder)) {
+      globalFolder = new URL(nodeModules, pathToFileURL(nvm))
+    }
+
+    return globalFolder
+  }
+)
 
 /**
  * Import `name` from `from` (and optionally the global `node_modules` directory).
@@ -142,6 +152,8 @@ export async function resolvePlugin(name, options) {
     // type-coverage:ignore-next-line -- TS fails on readonly arrays.
     Array.isArray(fromNonEmpty) ? fromNonEmpty : [fromNonEmpty]
   )
+
+  const defaultGlobal = electron || argv.startsWith(await npmPrefix)
   const globals =
     typeof settings.global === 'boolean' ? settings.global : defaultGlobal
   /** @type {string | undefined} */
@@ -152,7 +164,7 @@ export async function resolvePlugin(name, options) {
   // Bare specifier.
   if (name.charAt(0) !== '.') {
     if (globals) {
-      from.push(globalFolder)
+      from.push(await globalFolder)
     }
 
     let scope = ''

--- a/lib/index.js
+++ b/lib/index.js
@@ -149,7 +149,6 @@ export async function resolvePlugin(name, options) {
     : undefined
   const fromNonEmpty = settings.from || pathToFileURL(process.cwd() + '/')
   const from = /** @type {Array<Readonly<URL> | string>} */ (
-    // type-coverage:ignore-next-line -- TS fails on readonly arrays.
     Array.isArray(fromNonEmpty) ? fromNonEmpty : [fromNonEmpty]
   )
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -60,6 +60,7 @@ const config = new NpmConfig({
 // use the defaults.
 // See: <https://github.com/eush77/npm-prefix/blob/master/index.js>
 /** @type {string | Promise<string>} */
+// eslint-disable-next-line unicorn/prefer-top-level-await
 let npmPrefix = config.load().then(() => {
   npmPrefix =
     /* c8 ignore next 6 -- typically defined */
@@ -76,6 +77,7 @@ const defaultLoadOptions = {}
 const defaultResolveOptions = {}
 
 /** @type {URL | Promise<URL>} */
+// eslint-disable-next-line unicorn/prefer-top-level-await
 let globalFolder = /** @type {Promise<string>} */ (npmPrefix).then(
   (npmPrefix) => {
     /* c8 ignore next -- windows */

--- a/test/index.js
+++ b/test/index.js
@@ -270,11 +270,8 @@ test('loadPlugin', async function (t) {
   await t.test(
     'should support loading global packages (npm)',
     async function () {
-      try {
-        await loadPlugin('npm', {global: true})
-      } catch (error) {
-        assert.match(String(error), /The programmatic API was removed/)
-      }
+      const vowel = await loadPlugin('f-ck', {global: true, key: 'vowel'})
+      assert.equal(typeof vowel, 'function')
     }
   )
 })


### PR DESCRIPTION
This is an alternative to #18 to fix resolving global packages. This still uses `@npmcli/config`.

Just like #18, this fixes the problem that this package can’t be compiled to CJS.

Closes #18